### PR TITLE
Fix: rename external-dns charts

### DIFF
--- a/applications/core/external-dns-civo/external-dns-civo.yaml
+++ b/applications/core/external-dns-civo/external-dns-civo.yaml
@@ -21,7 +21,7 @@ spec:
     repoURL: https://kubernetes-sigs.github.io/external-dns/
     targetRevision: 1.13.0
     helm:
-      releaseName: external-dns
+      releaseName: external-dns-civo
       values: |
         provider: civo
         env:

--- a/applications/core/external-dns/external-dns.yaml
+++ b/applications/core/external-dns/external-dns.yaml
@@ -21,7 +21,7 @@ spec:
     repoURL: https://kubernetes-sigs.github.io/external-dns/
     targetRevision: 1.13.0
     helm:
-      releaseName: external-dns
+      releaseName: external-dns-cloudflare
       values: |
         provider: cloudflare
         env:


### PR DESCRIPTION
* Se renombran las release porque entran en conflicto al desplegarlas argo