### PR TITLE
fix(official-website): test chart name

### DIFF
--- a/environments/test/official-website.yaml
+++ b/environments/test/official-website.yaml
@@ -19,7 +19,7 @@ spec:
   sources:
     - repoURL: registry-1.docker.io/cloudnativerioja
       targetRevision: 0.0.24
-      chart: chart-official-website
+      chart: official-website
       helm:
         values: |
           ingress:


### PR DESCRIPTION
Fix with the right chart name: https://hub.docker.com/layers/cloudnativerioja/official-website/0.0.24/images/sha256-8276657a1ce2d3f85086f8519a5cb957e436701a73ae0ac3425e13542d92ad86?context=explore