### PR TITLE
Feat: add kyverno stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,54 +13,75 @@ Este repositorio contiene los manifests de Kubernetes para el cluster de Civo. S
 La estructura de carpetas es la siguiente:
 
 ```
-├── README.md
 ├── applications
-│   ├── core
-│   │   ├── argo-cd
-│   │   │   ├── argocd.yaml
-│   │   │   └── sso-secret.encrypted.yaml
-│   │   ├── cert-manager
-│   │   │   ├── cert-manager.yaml
-│   │   │   └── clusterissuer.yaml
-│   │   ├── cluster-autoscaler
-│   │   │   ├── bindings.yaml
-│   │   │   ├── clusterrole.yaml
-│   │   │   ├── deployment.yaml
-│   │   │   ├── role.yaml
-│   │   │   └── sa.yaml
-│   │   ├── env-test.yaml
-│   │   ├── external-dns
-│   │   │   ├── cloudflare-api-token.yaml
-│   │   │   └── external-dns.yaml
-│   │   ├── namespace.yaml
-│   │   ├── perm-manager
-│   │   │   └── permission-manager.yaml
-│   │   └── traefik
-│   │       ├── ingressroute.yaml
-│   │       └── traefik.yaml
-│   ├── monitoring
-│   │   ├── grafana
-│   │   │   ├── dashboards.yaml
-│   │   │   ├── datasources.yaml
-│   │   │   ├── github-sso-secred.encrypted.yaml
-│   │   │   ├── github-sso-secret.yaml
-│   │   │   └── grafana-operator.yaml
-│   │   ├── namespace.yaml
-│   │   └── prometheus
-│   │       └── kube-prometheus.yaml
-│   └── permission-manager
-│       ├── ingress.yaml
-│       ├── kustomization.yaml
-│       ├── namespace.yaml
-│       └── secret.encrypted.yaml
-└── environments
-    ├── prod
-    │   └── namespace.yaml
-    ├── staging
-    │   └── namespace.yaml
-    └── test
-        ├── namespace.yaml
-        └── official-website.yaml
+│   ├── core
+│   │   ├── argo-cd
+│   │   │   ├── argocd.yaml
+│   │   │   └── sso-secret.encrypted.yaml
+│   │   ├── cert-manager
+│   │   │   ├── cert-manager.yaml
+│   │   │   └── clusterissuer.yaml
+│   │   ├── cluster-autoscaler
+│   │   │   ├── bindings.yaml
+│   │   │   ├── clusterrole.yaml
+│   │   │   ├── deployment.yaml
+│   │   │   ├── role.yaml
+│   │   │   └── sa.yaml
+│   │   ├── env-test.yaml
+│   │   ├── external-dns
+│   │   │   ├── cloudflare-api-token.yaml
+│   │   │   └── external-dns.yaml
+│   │   ├── metrics-server
+│   │   │   └── metrics-server.yaml
+│   │   ├── monitoring
+│   │   │   └── prometheus-grafana.yaml
+│   │   ├── namespace.yaml
+│   │   ├── perm-manager
+│   │   │   └── permission-manager.yaml
+│   │   ├── security
+│   │   │   └── security.yaml
+│   │   └── traefik
+│   │       ├── ingressroute.yaml
+│   │       └── traefik.yaml
+│   ├── monitoring
+│   │   ├── grafana
+│   │   │   ├── dashboards
+│   │   │   │   ├── exporter-full-dashboard.yaml
+│   │   │   │   ├── k3s-dashboard.yaml
+│   │   │   │   └── loki-logs-dashboard.yaml
+│   │   │   ├── datasources.yaml
+│   │   │   ├── github-sso-secred.encrypted.yaml
+│   │   │   └── grafana-operator.yaml
+│   │   ├── loki
+│   │   │   └── loki.yaml
+│   │   ├── namespace.yaml
+│   │   └── prometheus
+│   │       └── kube-prometheus.yaml
+│   ├── permission-manager
+│   │   ├── ingress.yaml
+│   │   ├── kustomization.yaml
+│   │   ├── namespace.yaml
+│   │   └── secret.encrypted.yaml
+│   └── security
+│       └── kyverno
+│           ├── kyverno.yaml
+│           ├── namespace.yaml
+│           └── policies
+│               ├── mutate
+│               │   └── default-labels.yaml
+│               └── validation
+│                   ├── latest-tag.yaml
+│                   ├── limits-requests.yaml
+│                   └── no-default-ns.yaml
+├── environments
+│   ├── prod
+│   │   └── namespace.yaml
+│   ├── staging
+│   │   └── namespace.yaml
+│   └── test
+│       ├── namespace.yaml
+│       └── official-website.yaml
+└── README.md
 ```
 
 # POWERED BY [CIVO CLOUD](https://www.civo.com/)

--- a/applications/core/security/security.yaml
+++ b/applications/core/security/security.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: security
+  namespace: argocd
+spec:
+  destination:
+    name: ""
+    server: "https://kubernetes.default.svc"
+  source:
+    path: applications/security
+    repoURL: "https://github.com/cloudnativerioja/cluster-applications.git"
+    targetRevision: HEAD
+    directory:
+      recurse: true
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        maxDuration: 3m0s
+        factor: 2
+    syncOptions: []

--- a/applications/security/kyverno/kyverno.yaml
+++ b/applications/security/kyverno/kyverno.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: prometheus
+  name: kyverno
   namespace: argocd
 spec:
   project: default
@@ -19,24 +19,15 @@ spec:
         maxDuration: 3m0s
         factor: 2
   source:
-    repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 8.18.0
-    chart: kube-prometheus
+    repoURL: https://kyverno.github.io/kyverno/
+    targetRevision: v3.0.0
+    chart: kyverno
     helm:
       values: |
-        prometheus:
-          resources:
-            limits:
-              cpu: 512m
-              memory: 1Gi
-            requests:
-              cpu: 256m
-              memory: 512Mi
-        blackboxExporter:
+        reportsController:
           enabled: false
-        exporters:
-          kube-state-metrics:
-            enabled: true
+        cleanupController:
+          enabled: false
   destination:
     server: "https://kubernetes.default.svc"
-    namespace: monitoring
+    namespace: kyverno

--- a/applications/security/kyverno/namespace.yaml
+++ b/applications/security/kyverno/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kyverno

--- a/applications/security/kyverno/policies/mutate/default-labels.yaml
+++ b/applications/security/kyverno/policies/mutate/default-labels.yaml
@@ -8,9 +8,7 @@ metadata:
     policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Label
-    policies.kyverno.io/description: >-
-This policy performs a simple mutation which adds a label # yamllint disable-line rule:line-length
-      `CNCF-community-group: Cloud-Native-Rioja` to Pods, Services, ConfigMaps, and Secrets.
+    policies.kyverno.io/description: This policy performs a simple mutation which adds a label # yamllint disable-line rule:line-length
 spec:
   background: false
   rules:

--- a/applications/security/kyverno/policies/mutate/default-labels.yaml
+++ b/applications/security/kyverno/policies/mutate/default-labels.yaml
@@ -8,8 +8,8 @@ metadata:
     policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Label
-    # yamllint disable-line rule:line-length
     policies.kyverno.io/description: >-
+# yamllint disable-line rule:line-length
       Labels are used as an important source of metadata describing objects in various ways
       or triggering other functionality. Labels are also a very basic concept and should be
       used throughout Kubernetes. This policy performs a simple mutation which adds a label

--- a/applications/security/kyverno/policies/mutate/default-labels.yaml
+++ b/applications/security/kyverno/policies/mutate/default-labels.yaml
@@ -1,0 +1,32 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-labels
+  annotations:
+    policies.kyverno.io/title: Add Labels
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Label
+    policies.kyverno.io/description: >-
+      Labels are used as an important source of metadata describing objects in various ways
+      or triggering other functionality. Labels are also a very basic concept and should be
+      used throughout Kubernetes. This policy performs a simple mutation which adds a label
+      `CNCF-community-group: Cloud-Native-Rioja` to Pods, Services, ConfigMaps, and Secrets.
+spec:
+  background: false
+  rules:
+    - name: add-labels
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+                - Service
+                - ConfigMap
+                - Secret
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              CNCF-community-group: Cloud-Native-Rioja

--- a/applications/security/kyverno/policies/mutate/default-labels.yaml
+++ b/applications/security/kyverno/policies/mutate/default-labels.yaml
@@ -9,10 +9,7 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Label
     policies.kyverno.io/description: >-
-# yamllint disable-line rule:line-length
-      Labels are used as an important source of metadata describing objects in various ways
-      or triggering other functionality. Labels are also a very basic concept and should be
-      used throughout Kubernetes. This policy performs a simple mutation which adds a label
+This policy performs a simple mutation which adds a label # yamllint disable-line rule:line-length
       `CNCF-community-group: Cloud-Native-Rioja` to Pods, Services, ConfigMaps, and Secrets.
 spec:
   background: false

--- a/applications/security/kyverno/policies/mutate/default-labels.yaml
+++ b/applications/security/kyverno/policies/mutate/default-labels.yaml
@@ -8,6 +8,7 @@ metadata:
     policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Label
+    # yamllint disable-line rule:line-length
     policies.kyverno.io/description: >-
       Labels are used as an important source of metadata describing objects in various ways
       or triggering other functionality. Labels are also a very basic concept and should be

--- a/applications/security/kyverno/policies/validation/latest-tag.yaml
+++ b/applications/security/kyverno/policies/validation/latest-tag.yaml
@@ -10,10 +10,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
 # yamllint disable-line rule:line-length
-      The ':latest' tag is mutable and can lead to unexpected errors if the
-      image changes. A best practice is to use an immutable tag that maps to
-      a specific version of an application Pod. This policy validates that the image
-      specifies a tag and that it is not called `latest`.
+    This policy validates that the image specifies a tag and that it is not called `latest`.
 spec:
   validationFailureAction: Enforce
   background: true

--- a/applications/security/kyverno/policies/validation/latest-tag.yaml
+++ b/applications/security/kyverno/policies/validation/latest-tag.yaml
@@ -8,6 +8,7 @@ metadata:
     policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
+    # yamllint disable-line rule:line-length
     policies.kyverno.io/description: >-
       The ':latest' tag is mutable and can lead to unexpected errors if the
       image changes. A best practice is to use an immutable tag that maps to

--- a/applications/security/kyverno/policies/validation/latest-tag.yaml
+++ b/applications/security/kyverno/policies/validation/latest-tag.yaml
@@ -8,8 +8,8 @@ metadata:
     policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
-    # yamllint disable-line rule:line-length
     policies.kyverno.io/description: >-
+# yamllint disable-line rule:line-length
       The ':latest' tag is mutable and can lead to unexpected errors if the
       image changes. A best practice is to use an immutable tag that maps to
       a specific version of an application Pod. This policy validates that the image

--- a/applications/security/kyverno/policies/validation/latest-tag.yaml
+++ b/applications/security/kyverno/policies/validation/latest-tag.yaml
@@ -1,0 +1,43 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-latest-tag
+  annotations:
+    policies.kyverno.io/title: Disallow Latest Tag
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The ':latest' tag is mutable and can lead to unexpected errors if the
+      image changes. A best practice is to use an immutable tag that maps to
+      a specific version of an application Pod. This policy validates that the image
+      specifies a tag and that it is not called `latest`.
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: require-image-tag
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: "An image tag is required."
+        pattern:
+          spec:
+            containers:
+              - image: "*:*"
+    - name: validate-image-tag
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: "Using a mutable image tag e.g. 'latest' is not allowed."
+        pattern:
+          spec:
+            containers:
+              - image: "!*:latest"

--- a/applications/security/kyverno/policies/validation/latest-tag.yaml
+++ b/applications/security/kyverno/policies/validation/latest-tag.yaml
@@ -8,9 +8,7 @@ metadata:
     policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
-    policies.kyverno.io/description: >-
-# yamllint disable-line rule:line-length
-    This policy validates that the image specifies a tag and that it is not called `latest`.
+    policies.kyverno.io/description: This policy validates that the image specifies a tag and that it is not called `latest`. # yamllint disable-line rule:line-length
 spec:
   validationFailureAction: Enforce
   background: true

--- a/applications/security/kyverno/policies/validation/limits-requests.yaml
+++ b/applications/security/kyverno/policies/validation/limits-requests.yaml
@@ -8,8 +8,8 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.6.0
-    # yamllint disable-line rule:line-length
     policies.kyverno.io/description: >-
+# yamllint disable-line rule:line-length
       As application workloads share cluster resources, it is important to limit resources
       requested and consumed by each Pod. It is recommended to require resource requests and
       limits per Pod, especially for memory and CPU. If a Namespace level request or limit is specified,

--- a/applications/security/kyverno/policies/validation/limits-requests.yaml
+++ b/applications/security/kyverno/policies/validation/limits-requests.yaml
@@ -1,0 +1,38 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-requests-limits
+  annotations:
+    policies.kyverno.io/title: Require Limits and Requests
+    policies.kyverno.io/category: Best Practices, EKS Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/description: >-
+      As application workloads share cluster resources, it is important to limit resources
+      requested and consumed by each Pod. It is recommended to require resource requests and
+      limits per Pod, especially for memory and CPU. If a Namespace level request or limit is specified,
+      defaults will automatically be applied to each Pod based on the LimitRange configuration.
+      This policy validates that all containers have something specified for memory and CPU
+      requests and memory limits.
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: validate-resources
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: "CPU and memory resource requests and limits are required."
+        pattern:
+          spec:
+            containers:
+              - resources:
+                  requests:
+                    memory: "?*"
+                    cpu: "?*"
+                  limits:
+                    memory: "?*"

--- a/applications/security/kyverno/policies/validation/limits-requests.yaml
+++ b/applications/security/kyverno/policies/validation/limits-requests.yaml
@@ -10,12 +10,7 @@ metadata:
     policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/description: >-
 # yamllint disable-line rule:line-length
-      As application workloads share cluster resources, it is important to limit resources
-      requested and consumed by each Pod. It is recommended to require resource requests and
-      limits per Pod, especially for memory and CPU. If a Namespace level request or limit is specified,
-      defaults will automatically be applied to each Pod based on the LimitRange configuration.
-      This policy validates that all containers have something specified for memory and CPU
-      requests and memory limits.
+      This policy validates that all containers have something specified for memory and CPU requests and memory limits.
 spec:
   validationFailureAction: Enforce
   background: true

--- a/applications/security/kyverno/policies/validation/limits-requests.yaml
+++ b/applications/security/kyverno/policies/validation/limits-requests.yaml
@@ -8,9 +8,7 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.6.0
-    policies.kyverno.io/description: >-
-# yamllint disable-line rule:line-length
-      This policy validates that all containers have something specified for memory and CPU requests and memory limits.
+    policies.kyverno.io/description: This policy validates that all containers have something specified for memory and CPU requests and memory limits. # yamllint disable-line rule:line-length
 spec:
   validationFailureAction: Enforce
   background: true

--- a/applications/security/kyverno/policies/validation/limits-requests.yaml
+++ b/applications/security/kyverno/policies/validation/limits-requests.yaml
@@ -8,6 +8,7 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.6.0
+    # yamllint disable-line rule:line-length
     policies.kyverno.io/description: >-
       As application workloads share cluster resources, it is important to limit resources
       requested and consumed by each Pod. It is recommended to require resource requests and

--- a/applications/security/kyverno/policies/validation/no-default-ns.yaml
+++ b/applications/security/kyverno/policies/validation/no-default-ns.yaml
@@ -9,8 +9,8 @@ metadata:
     policies.kyverno.io/category: Multi-Tenancy
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
-    # yamllint disable-line rule:line-length
     policies.kyverno.io/description: >-
+# yamllint disable-line rule:line-length
       Kubernetes Namespaces are an optional feature that provide a way to segment and
       isolate cluster resources across multiple applications and users. As a best
       practice, workloads should be isolated with Namespaces. Namespaces should be required

--- a/applications/security/kyverno/policies/validation/no-default-ns.yaml
+++ b/applications/security/kyverno/policies/validation/no-default-ns.yaml
@@ -9,9 +9,7 @@ metadata:
     policies.kyverno.io/category: Multi-Tenancy
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
-    policies.kyverno.io/description: >-
-# yamllint disable-line rule:line-length
-      This policy validates that Pods specify a Namespace name other than `default`.
+    policies.kyverno.io/description: This policy validates that Pods specify a Namespace name other than `default`. # yamllint disable-line rule:line-length
 spec:
   validationFailureAction: Enforce
   background: true

--- a/applications/security/kyverno/policies/validation/no-default-ns.yaml
+++ b/applications/security/kyverno/policies/validation/no-default-ns.yaml
@@ -11,13 +11,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
 # yamllint disable-line rule:line-length
-      Kubernetes Namespaces are an optional feature that provide a way to segment and
-      isolate cluster resources across multiple applications and users. As a best
-      practice, workloads should be isolated with Namespaces. Namespaces should be required
-      and the default (empty) Namespace should not be used. This policy validates that Pods
-      specify a Namespace name other than `default`. Rule auto-generation is disabled here
-      due to Pod controllers need to specify the `namespace` field under the top-level `metadata`
-      object and not at the Pod template level. # yamllint disable-line rule:line-length
+      This policy validates that Pods specify a Namespace name other than `default`.
 spec:
   validationFailureAction: Enforce
   background: true

--- a/applications/security/kyverno/policies/validation/no-default-ns.yaml
+++ b/applications/security/kyverno/policies/validation/no-default-ns.yaml
@@ -9,6 +9,7 @@ metadata:
     policies.kyverno.io/category: Multi-Tenancy
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
+    # yamllint disable-line rule:line-length
     policies.kyverno.io/description: >-
       Kubernetes Namespaces are an optional feature that provide a way to segment and
       isolate cluster resources across multiple applications and users. As a best
@@ -16,7 +17,7 @@ metadata:
       and the default (empty) Namespace should not be used. This policy validates that Pods
       specify a Namespace name other than `default`. Rule auto-generation is disabled here
       due to Pod controllers need to specify the `namespace` field under the top-level `metadata`
-      object and not at the Pod template level.
+      object and not at the Pod template level. # yamllint disable-line rule:line-length
 spec:
   validationFailureAction: Enforce
   background: true

--- a/applications/security/kyverno/policies/validation/no-default-ns.yaml
+++ b/applications/security/kyverno/policies/validation/no-default-ns.yaml
@@ -1,0 +1,48 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-default-namespace
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
+    policies.kyverno.io/title: Disallow Default Namespace
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Kubernetes Namespaces are an optional feature that provide a way to segment and
+      isolate cluster resources across multiple applications and users. As a best
+      practice, workloads should be isolated with Namespaces. Namespaces should be required
+      and the default (empty) Namespace should not be used. This policy validates that Pods
+      specify a Namespace name other than `default`. Rule auto-generation is disabled here
+      due to Pod controllers need to specify the `namespace` field under the top-level `metadata`
+      object and not at the Pod template level.
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: validate-namespace
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: "Using 'default' namespace is not allowed."
+        pattern:
+          metadata:
+            namespace: "!default"
+    - name: validate-podcontroller-namespace
+      match:
+        any:
+          - resources:
+              kinds:
+                - DaemonSet
+                - Deployment
+                - Job
+                - StatefulSet
+      validate:
+        message: "Using 'default' namespace is not allowed for pod controllers."
+        pattern:
+          metadata:
+            namespace: "!default"


### PR DESCRIPTION
resolves #71 
* Add kyverno application
* Add kyverno namespace 
* Add kyverno mutate and validation policies
* Rollback with kube-state-metrics

***VALIDATION RULES***

From now:
* When some resource is deployed, kyverno add the label _CNCF-community-group: Cloud-Native-Rioja_
* It would be mandatory create resource limits and requests for each deployment in the cluster
* It would be forbidden create resources in default namespace
* It would be forbidden use the latest tag in containers