### PR TITLE
Feat: minimum of three nodes as baseline

### DIFF
--- a/applications/core/cluster-autoscaler/deployment.yaml
+++ b/applications/core/cluster-autoscaler/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - --v=4
             - --stderrthreshold=info
             - --cloud-provider=civo
-            - --nodes=1:5:workers
+            - --nodes=3:5:workers
             - --skip-nodes-with-local-storage=false
             - --skip-nodes-with-system-pods=false
           env:


### PR DESCRIPTION
<!--- 🚀 Pull Request Template 🚀 -->

## Description 📝
It is proposed to set a node baseline of three nodes. Prometheus stack and other apps are consuming almost all ram memory.

## Related Issues 🔗

## Screenshots/Visuals 📸
![image](https://github.com/cloudnativerioja/cluster-applications/assets/97036642/56962511-51cc-4346-83cd-ce7c41a4a21d)

## Testing Checklist 🧪

✅ Please check the following items before submitting your PR:

- [ ] Code compiles and runs successfully.
- [x] All existing tests pass.
- [ ] Added new tests (if applicable).
- [ ] Documentation is updated (if applicable).
- [x] Followed coding style and best practices.
- [x] Reviewed your own code.

## Additional Comments 💬

<!--- 🙏 Thank you for your contribution! 🙏 -->
