### PR TITLE
Fix: increase minio memory

### DIFF
--- a/applications/core/minio/minio.yaml
+++ b/applications/core/minio/minio.yaml
@@ -58,9 +58,9 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 256Mi
+            memory: 512Mi
           limits:
-            memory: 256Mi
+            memory: 512Mi
   destination:
     server: "https://kubernetes.default.svc"
     namespace: core-apps


### PR DESCRIPTION
<!--- 🚀 Pull Request Template 🚀 -->

## Description 📝
* Increase minio memory limit to 512Mi
## Related Issues 🔗

## Screenshots/Visuals 📸
![image](https://github.com/cloudnativerioja/cluster-applications/assets/97036642/9242045b-0fbd-43ec-9126-7a98d7cbd565)

## Testing Checklist 🧪

✅ Please check the following items before submitting your PR:

- [ ] Code compiles and runs successfully.
- [ ] All existing tests pass.
- [ ] Added new tests (if applicable).
- [ ] Documentation is updated (if applicable).
- [ ] Followed coding style and best practices.
- [x] Reviewed your own code.

## Additional Comments 💬

<!--- 🙏 Thank you for your contribution! 🙏 -->
