### PR TITLE
Feat: change argocd tls configuration

### DIFF
--- a/applications/core/argocd/argocd.yaml
+++ b/applications/core/argocd/argocd.yaml
@@ -77,7 +77,6 @@ spec:
             ingressClassName: ""
             hosts:
               - argo.cloudnativerioja.com
-              # - argocd.example.com
             # -- List of ingress paths
             paths:
               - /
@@ -92,8 +91,7 @@ spec:
                     name: argocd-server
                     port:
                       number: 443
-            # -- Ingress TLS configuration
-            tls:
+            extraTls:
               - hosts:
                   - argo.cloudnativerioja.com
                 secretName: tls-argo-cloudnativerioja-com


### PR DESCRIPTION
<!--- 🚀 Pull Request Template 🚀 -->

## Description 📝
* Related to [this](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml#L2927C5-L2927C14)
## Related Issues 🔗
* Error: `Ingress.extensions "argocd-server" is invalid: spec.tls[0].hosts[0]: Invalid value: "": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or ' ││ .', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`
## Screenshots/Visuals 📸

## Testing Checklist 🧪

✅ Please check the following items before submitting your PR:

- [ ] Code compiles and runs successfully.
- [ ] All existing tests pass.
- [ ] Added new tests (if applicable).
- [ ] Documentation is updated (if applicable).
- [ ] Followed coding style and best practices.
- [ ] Reviewed your own code.

## Additional Comments 💬

<!--- 🙏 Thank you for your contribution! 🙏 -->
